### PR TITLE
add support for reading config files from configs subdir of deploy directory

### DIFF
--- a/src/main/java/com/team766/hal/simulator/RobotMain.java
+++ b/src/main/java/com/team766/hal/simulator/RobotMain.java
@@ -22,6 +22,7 @@ public class RobotMain {
 	
 	public RobotMain(Mode mode) {
 		try {
+			// TODO: update this to come from deploy directory? 
 			ConfigFileReader.instance = new ConfigFileReader("simConfig.txt");
 			RobotProvider.instance = new SimulationRobotProvider();
 			

--- a/src/main/java/com/team766/hal/wpilib/RobotMain.java
+++ b/src/main/java/com/team766/hal/wpilib/RobotMain.java
@@ -68,9 +68,9 @@ public class RobotMain extends TimedRobot {
 			filename = checkForAndReturnPathToConfigFile(SELECTED_CONFIG_FILE);
 			
 			if (filename == null) {
-				checkForAndReturnPathToConfigFile(DEFAULT_CONFIG_FILE);
+				filename = checkForAndReturnPathToConfigFile(DEFAULT_CONFIG_FILE);
 			}
-			
+
 			if (filename == null) {
 				filename = LEGACY_CONFIG_FILE;
 			}

--- a/src/main/java/com/team766/hal/wpilib/RobotMain.java
+++ b/src/main/java/com/team766/hal/wpilib/RobotMain.java
@@ -1,15 +1,32 @@
 package com.team766.hal.wpilib;
 
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.function.Supplier;
 import com.team766.config.ConfigFileReader;
 import com.team766.framework.Scheduler;
 import com.team766.hal.GenericRobotMain;
 import com.team766.hal.RobotProvider;
 import com.team766.logging.LoggerExceptionUtils;
+import edu.wpi.first.wpilibj.Filesystem;
 import edu.wpi.first.wpilibj.RobotBase;
 import edu.wpi.first.wpilibj.TimedRobot;
 
 public class RobotMain extends TimedRobot {
+	// this file, if present, will be a symlink to one of several config files in the deploy directory.
+	// this allows for the same code to be deployed to multiple physical robots, each with their own
+	// config file with CAN bus port mappings, etc, with the actual file used for a specific robot
+	// to be "selected" via this symlink to the actual file.
+	private final static String SELECTED_CONFIG_FILE = "configs/selectedConfig.txt";
+
+	// if the symlink (above) is not present, back off to this file in the deploy directory.
+	private final static String DEFAULT_CONFIG_FILE = "configs/robotConfig.txt";
+
+	// for backwards compatibility, back off to the previous config file location if the above are not
+	// found in the deploy directory.
+	private final static String LEGACY_CONFIG_FILE = "/home/lvuser/robotConfig.txt";
+
 	private GenericRobotMain robot;
 
 	public static void main(String... args) {
@@ -35,10 +52,30 @@ public class RobotMain extends TimedRobot {
 		super(0.005);
 	}
 
+	private static String checkForAndReturnPathToConfigFile(String file) {
+		Path configPath = Filesystem.getDeployDirectory().toPath().resolve(file);
+		File configFile = configPath.toFile();	
+		if (configFile.exists()) {
+			return configFile.getPath();
+		}
+		return null;
+	}
+
 	@Override
 	public void robotInit() {
 		try {
-			ConfigFileReader.instance = new ConfigFileReader("/home/lvuser/robotConfig.txt");
+			String filename = null;
+			filename = checkForAndReturnPathToConfigFile(SELECTED_CONFIG_FILE);
+			
+			if (filename == null) {
+				checkForAndReturnPathToConfigFile(DEFAULT_CONFIG_FILE);
+			}
+			
+			if (filename == null) {
+				filename = LEGACY_CONFIG_FILE;
+			}
+
+			ConfigFileReader.instance = new ConfigFileReader(filename);
 			RobotProvider.instance = new WPIRobotProvider();
 			robot = new GenericRobotMain();
 			

--- a/src/main/java/com/team766/hal/wpilib/RobotMain.java
+++ b/src/main/java/com/team766/hal/wpilib/RobotMain.java
@@ -18,10 +18,10 @@ public class RobotMain extends TimedRobot {
 	// this allows for the same code to be deployed to multiple physical robots, each with their own
 	// config file with CAN bus port mappings, etc, with the actual file used for a specific robot
 	// to be "selected" via this symlink to the actual file.
-	private final static String SELECTED_CONFIG_FILE = "configs/selectedConfig.txt";
+	private final static String SELECTED_CONFIG_FILE = "/home/lvuser/selectedConfig.txt";
 
 	// if the symlink (above) is not present, back off to this file in the deploy directory.
-	private final static String DEFAULT_CONFIG_FILE = "configs/robotConfig.txt";
+	private final static String DEFAULT_CONFIG_FILE = "configs/defaultRobotConfig.txt";
 
 	// for backwards compatibility, back off to the previous config file location if the above are not
 	// found in the deploy directory.


### PR DESCRIPTION
allows config files to be managed in version control, with rest of robot code.

config file looks for /home/lvuser/selectedConfig.txt first - should be a symlink to one of potentially several config files in configs dir.
if that doesn't exist, looks for <deploy>/configs/defaultRobotConfig.txt.
if that doesn't exist, looks for /home/lvuser/robotConfig.txt as per current behavior.

subsequent change will check in a default robotConfig.txt.  also need to work through file permissions as deployed files are owned by "admin" and robot code runs as "lvuser".

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/team766/maroonframework/11)
<!-- Reviewable:end -->
