### PR TITLE
Use HTTP endpoint for deploying code to simulators

### DIFF
--- a/deploy_sim.sh
+++ b/deploy_sim.sh
@@ -50,9 +50,10 @@ cp "$jar_file" "$deployed_code/project.jar"
 cp -R src/main/deploy "$deployed_code"
 cp simConfig.txt "$deployed_code"
 
-scp -o "StrictHostKeyChecking=no" -r "$deployed_code" "${user}@${server}":"$deployed_code"
+deployed_package=${deployed_code}.tgz
+tar cfz ${deployed_package} -C ${deployed_code} .
 
-ssh -o "StrictHostKeyChecking=no" "${user}@${server}" "launch_robot_code.sh $deployed_code $@"
+curl -F "package=@${deployed_package}" ${server}:4000/uploadrobotcode
 
 set +x
 echo -e "\nDeploy finished. Your code is running"


### PR DESCRIPTION
https://github.com/Team766/CloudProgrammingEnvironment/commit/1b730fcc020268c034b6f9caedc82585cb74d5e4 added a new HTTP endpoint that can be used to upload robot code to the simulators instead of using SCP/SSH. This PR switches the `deploy_sim.sh` script to use this new method.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/team766/maroonframework/14)
<!-- Reviewable:end -->
