### PR TITLE
remove Maroon Framework maven publishing target for 2023 repo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -143,22 +143,4 @@ protobuf {
   }
 }
 
-publishing {
-    repositories {
-        maven {
-            name = "GitHubPackages"
-            url = uri("https://maven.pkg.github.com/Team766/MaroonFramework")
-            credentials {
-                username = System.getenv("GITHUB_ACTOR")
-                password = System.getenv("GITHUB_TOKEN")
-            }
-        }
-    }
-    publications {
-        gpr(MavenPublication) {
-            artifactId "maroonframework"
-            from(components.java)
-        }
-    }
-}
 


### PR DESCRIPTION
Maroon Framework fork
publishes lib to maven
don't want so delete

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Team766/MaroonFramework/17)
<!-- Reviewable:end -->
