### PR TITLE
Beacon position sensor for simulator

### DIFF
--- a/src/main/java/com/team766/hal/BeaconReader.java
+++ b/src/main/java/com/team766/hal/BeaconReader.java
@@ -1,0 +1,14 @@
+package com.team766.hal;
+
+public interface BeaconReader {
+	public static class BeaconPose {
+		public double x;
+		public double y;
+		public double z;
+		public double yaw;
+		public double pitch;
+		public double roll;
+	}
+
+	public abstract BeaconPose[] getBeacons();
+}

--- a/src/main/java/com/team766/hal/RobotProvider.java
+++ b/src/main/java/com/team766/hal/RobotProvider.java
@@ -29,6 +29,7 @@ public abstract class RobotProvider {
 	protected AnalogInputReader[] angInputs = new AnalogInputReader[5];
 	protected RelayOutput[] relays = new RelayOutput[5];
 	protected PositionReader positionSensor = null;
+	protected BeaconReader beaconSensor = null;
 
 	private HashMap<Integer, String> motorDeviceIdNames = new HashMap<Integer, String>();
 	private HashMap<Integer, String> motorPortNames = new HashMap<Integer, String>();
@@ -56,6 +57,8 @@ public abstract class RobotProvider {
 	public abstract CameraReader getCamera(String id, String value);
 
 	public abstract PositionReader getPositionSensor();
+
+	public abstract BeaconReader getBeaconSensor();
 
 	public static TimeProviderI getTimeProvider(){
 		return () -> instance.getClock().getTime();

--- a/src/main/java/com/team766/hal/mock/MockBeaconSensor.java
+++ b/src/main/java/com/team766/hal/mock/MockBeaconSensor.java
@@ -1,0 +1,12 @@
+package com.team766.hal.mock;
+
+import com.team766.hal.BeaconReader;
+
+public class MockBeaconSensor implements BeaconReader {
+
+	@Override
+	public BeaconPose[] getBeacons() {
+		return new BeaconPose[0];
+	}
+
+}

--- a/src/main/java/com/team766/hal/mock/TestRobotProvider.java
+++ b/src/main/java/com/team766/hal/mock/TestRobotProvider.java
@@ -37,43 +37,49 @@ public class TestRobotProvider extends RobotProvider{
 
 	@Override
 	public EncoderReader getEncoder(int index1, int index2) {
-		if(encoders[index1] == null)
+		if(encoders[index1] == null) {
 			encoders[index1] = new MockEncoder(index1, index2);
+		}
 		return encoders[index1];
 	}
 
 	@Override
 	public SolenoidController getSolenoid(int index) {
-		if(solenoids[index] == null)
+		if(solenoids[index] == null) {
 			solenoids[index] = new MockSolenoid(index);
+		}
 		return solenoids[index];
 	}
 
 	@Override
 	public GyroReader getGyro(int index) {
-		if(gyros[0] == null)
+		if(gyros[0] == null) {
 			gyros[0] = new MockGyro();
+		}
 		return gyros[0];
 	}
 
 	@Override
 	public CameraReader getCamera(String id, String value) {
-		if(!cams.containsKey(id))
+		if(!cams.containsKey(id)) {
 			cams.put(id, new MockCamera());
+		}
 		return cams.get(id);
 	}
 
 	@Override
 	public JoystickReader getJoystick(int index) {
-		if(joysticks[index] == null)
+		if(joysticks[index] == null) {
 			joysticks[index] = new MockJoystick();
+		}
 		return joysticks[index];
 	}
 	
 	@Override
 	public DigitalInputReader getDigitalInput(int index) {
-		if(digInputs[index] == null)
+		if(digInputs[index] == null) {
 			digInputs[index] = new MockDigitalInput();
+		}
 		return digInputs[index];
 	}
 
@@ -84,28 +90,32 @@ public class TestRobotProvider extends RobotProvider{
 	
 	@Override
 	public AnalogInputReader getAnalogInput(int index) {
-		if(angInputs[index] == null)
+		if(angInputs[index] == null) {
 			angInputs[index] = new MockAnalogInput();
+		}
 		return angInputs[index];
 	}
 	
 	public RelayOutput getRelay(int index) {
-		if(relays[index] == null)
+		if(relays[index] == null) {
 			relays[index] = new MockRelay(index);
+		}
 		return relays[index];
 	}
 
 	@Override
 	public PositionReader getPositionSensor() {
-		if (positionSensor == null)
+		if (positionSensor == null) {
 			positionSensor = new MockPositionSensor();
+		}
 		return positionSensor;
 	}
 	
 	@Override
 	public BeaconReader getBeaconSensor() {
-		if (beaconSensor == null)
+		if (beaconSensor == null) {
 			beaconSensor = new MockBeaconSensor();
+		}
 		return beaconSensor;
 	}
 

--- a/src/main/java/com/team766/hal/mock/TestRobotProvider.java
+++ b/src/main/java/com/team766/hal/mock/TestRobotProvider.java
@@ -1,6 +1,7 @@
 package com.team766.hal.mock;
 
 import com.team766.hal.AnalogInputReader;
+import com.team766.hal.BeaconReader;
 import com.team766.hal.CameraInterface;
 import com.team766.hal.CameraReader;
 import com.team766.hal.Clock;
@@ -99,6 +100,13 @@ public class TestRobotProvider extends RobotProvider{
 		if (positionSensor == null)
 			positionSensor = new MockPositionSensor();
 		return positionSensor;
+	}
+	
+	@Override
+	public BeaconReader getBeaconSensor() {
+		if (beaconSensor == null)
+			beaconSensor = new MockBeaconSensor();
+		return beaconSensor;
 	}
 
 	@Override

--- a/src/main/java/com/team766/hal/simulator/BeaconSensor.java
+++ b/src/main/java/com/team766/hal/simulator/BeaconSensor.java
@@ -1,0 +1,13 @@
+package com.team766.hal.simulator;
+
+import com.team766.hal.BeaconReader;
+import com.team766.simulator.ProgramInterface;
+
+public class BeaconSensor implements BeaconReader {
+
+	@Override
+	public BeaconPose[] getBeacons() {
+		return ProgramInterface.beacons;
+	}
+
+}

--- a/src/main/java/com/team766/hal/simulator/SimulationRobotProvider.java
+++ b/src/main/java/com/team766/hal/simulator/SimulationRobotProvider.java
@@ -1,6 +1,7 @@
 package com.team766.hal.simulator;
 
 import com.team766.hal.AnalogInputReader;
+import com.team766.hal.BeaconReader;
 import com.team766.hal.CameraInterface;
 import com.team766.hal.CameraReader;
 import com.team766.hal.Clock;
@@ -97,6 +98,13 @@ public class SimulationRobotProvider extends RobotProvider{
 		if (positionSensor == null)
 			positionSensor = new PositionSensor();
 		return positionSensor;
+	}
+
+	@Override
+	public BeaconReader getBeaconSensor() {
+		if (beaconSensor == null)
+			beaconSensor = new BeaconSensor();
+		return beaconSensor;
 	}
 
 	@Override

--- a/src/main/java/com/team766/hal/simulator/SimulationRobotProvider.java
+++ b/src/main/java/com/team766/hal/simulator/SimulationRobotProvider.java
@@ -37,29 +37,33 @@ public class SimulationRobotProvider extends RobotProvider{
 
 	@Override
 	public EncoderReader getEncoder(int index1, int index2) {
-		if(encoders[index1] == null)
+		if(encoders[index1] == null) {
 			encoders[index1] = new Encoder(index1, index2);
+		}
 		return encoders[index1];
 	}
 
 	@Override
 	public SolenoidController getSolenoid(int index) {
-		if(solenoids[index] == null)
+		if(solenoids[index] == null) {
 			solenoids[index] = new Solenoid(index);
+		}
 		return solenoids[index];
 	}
 
 	@Override
 	public GyroReader getGyro(int index) {
-		if(gyros[0] == null)
+		if(gyros[0] == null) {
 			gyros[0] = new Gyro();
+		}
 		return gyros[0];
 	}
 
 	@Override
 	public CameraReader getCamera(String id, String value) {
-		if(!cams.containsKey(id))
+		if(!cams.containsKey(id)) {
 			cams.put(id, new Camera());
+		}
 		return cams.get(id);
 	}
 
@@ -70,8 +74,9 @@ public class SimulationRobotProvider extends RobotProvider{
 	
 	@Override
 	public DigitalInputReader getDigitalInput(int index) {
-		if(digInputs[index] == null)
+		if(digInputs[index] == null) {
 			digInputs[index] = new DigitalInput(index);
+		}
 		return digInputs[index];
 	}
 
@@ -82,28 +87,32 @@ public class SimulationRobotProvider extends RobotProvider{
 	
 	@Override
 	public AnalogInputReader getAnalogInput(int index) {
-		if(angInputs[index] == null)
+		if(angInputs[index] == null) {
 			angInputs[index] = new AnalogInput(index);
+		}
 		return angInputs[index];
 	}
 	
 	public RelayOutput getRelay(int index) {
-		if(relays[index] == null)
+		if(relays[index] == null) {
 			relays[index] = new Relay(index);
+		}
 		return relays[index];
 	}
 
 	@Override
 	public PositionReader getPositionSensor() {
-		if (positionSensor == null)
+		if (positionSensor == null) {
 			positionSensor = new PositionSensor();
+		}
 		return positionSensor;
 	}
 
 	@Override
 	public BeaconReader getBeaconSensor() {
-		if (beaconSensor == null)
+		if (beaconSensor == null) {
 			beaconSensor = new BeaconSensor();
+		}
 		return beaconSensor;
 	}
 

--- a/src/main/java/com/team766/hal/simulator/VrConnector.java
+++ b/src/main/java/com/team766/hal/simulator/VrConnector.java
@@ -94,6 +94,9 @@ public class VrConnector implements Runnable {
 	private static final int ROBOT_X_CHANNEL = 8;
 	private static final int ROBOT_Y_CHANNEL = 9;
 
+	private static final int BEACON_SENSOR_START = 120;
+	private static final int BEACON_SENSOR_STRIDE = 6; // (x, y, z, yaw, pitch, roll)
+
 	private static final List<PortMapping> ENCODER_CHANNELS = Arrays.asList(
 		new PortMapping(10, 0), // Left encoder
 		new PortMapping(11, 2), // Right encoder
@@ -247,6 +250,15 @@ public class VrConnector implements Runnable {
 			ProgramInterface.gyro.rate = getFeedback(GYRO_RATE_CHANNEL) / 100.0;
 			ProgramInterface.gyro.pitch = normalizeAngleDegrees(getFeedback(GYRO_PITCH_CHANNEL) / 10.0);
 			ProgramInterface.gyro.roll = normalizeAngleDegrees(getFeedback(GYRO_ROLL_CHANNEL) / 10.0);
+
+			for (int i = 0; i < ProgramInterface.NUM_BEACONS; ++i) {
+				ProgramInterface.beacons[i].x = getFeedback(BEACON_SENSOR_START + i * BEACON_SENSOR_STRIDE + 0) / 1000.0;
+				ProgramInterface.beacons[i].y = getFeedback(BEACON_SENSOR_START + i * BEACON_SENSOR_STRIDE + 1) / 1000.0;
+				ProgramInterface.beacons[i].z = getFeedback(BEACON_SENSOR_START + i * BEACON_SENSOR_STRIDE + 2) / 1000.0;
+				ProgramInterface.beacons[i].yaw = getFeedback(BEACON_SENSOR_START + i * BEACON_SENSOR_STRIDE + 3) / 1000.0;
+				ProgramInterface.beacons[i].pitch = getFeedback(BEACON_SENSOR_START + i * BEACON_SENSOR_STRIDE + 4) / 1000.0;
+				ProgramInterface.beacons[i].roll = getFeedback(BEACON_SENSOR_START + i * BEACON_SENSOR_STRIDE + 5) / 1000.0;
+			}
 
 			for (PortMapping m : ENCODER_CHANNELS) {
 				final long value = getFeedback(m.messageDataIndex);

--- a/src/main/java/com/team766/hal/wpilib/WPIRobotProvider.java
+++ b/src/main/java/com/team766/hal/wpilib/WPIRobotProvider.java
@@ -83,15 +83,17 @@ public class WPIRobotProvider extends RobotProvider {
 
 	@Override
 	public EncoderReader getEncoder(int index1, int index2) {
-		if(encoders[index1] == null)
+		if(encoders[index1] == null) {
 			encoders[index1] = new Encoder(index1, index2);
+		}
 		return encoders[index1];
 	}
 
 	@Override
 	public SolenoidController getSolenoid(int index) {
-		if(solenoids[index] == null)
+		if(solenoids[index] == null) {
 			solenoids[index] = new Solenoid(index);
+		}
 		return solenoids[index];
 	}
 
@@ -107,13 +109,13 @@ public class WPIRobotProvider extends RobotProvider {
 					"Invalid gyro port " + index + ". Must be -2, -1, or a non-negative integer"
 				);
 				return new MockGyro();
-			}
-			else if(index == -2)
+			} else if(index == -2) {
 				gyros[index + 2] = new NavXGyro(I2C.Port.kOnboard);
-			else if(index == -1)
+			} else if(index == -1) {
 				gyros[index + 2] = new ADXRS450_Gyro(SPI.Port.kOnboardCS0);
-			else
+			} else {
 				gyros[index + 2] = new AnalogGyro(index);
+			}
 		}
 		return gyros[index + 2];
 	}
@@ -126,8 +128,9 @@ public class WPIRobotProvider extends RobotProvider {
 
 	@Override
 	public JoystickReader getJoystick(int index) {
-		if(joysticks[index] == null)
+		if(joysticks[index] == null) {
 			joysticks[index] = new Joystick(index);
+		}
 		return joysticks[index];
 	}
 
@@ -138,22 +141,25 @@ public class WPIRobotProvider extends RobotProvider {
 
 	@Override
 	public DigitalInputReader getDigitalInput(int index) {
-		if (digInputs[index] == null)
+		if (digInputs[index] == null) {
 			digInputs[index] = new DigitalInput(index);
+		}
 		return digInputs[index];
 	}
 
 	@Override
 	public AnalogInputReader getAnalogInput(int index){
-		if(angInputs[index] == null)
+		if(angInputs[index] == null) {
 			angInputs[index] = new AnalogInput(index);
+		}
 		return angInputs[index];
 	}
 
 	@Override
 	public RelayOutput getRelay(int index) {
-		if(relays[index] == null)
+		if(relays[index] == null) {
 			relays[index] = new Relay(index);
+		}
 		return relays[index];
 	}
 

--- a/src/main/java/com/team766/hal/wpilib/WPIRobotProvider.java
+++ b/src/main/java/com/team766/hal/wpilib/WPIRobotProvider.java
@@ -1,6 +1,7 @@
 package com.team766.hal.wpilib;
 
 import com.team766.hal.AnalogInputReader;
+import com.team766.hal.BeaconReader;
 import com.team766.hal.CameraInterface;
 import com.team766.hal.CameraReader;
 import com.team766.hal.Clock;
@@ -15,6 +16,7 @@ import com.team766.hal.RelayOutput;
 import com.team766.hal.RobotProvider;
 import com.team766.hal.SolenoidController;
 import com.team766.hal.MotorController;
+import com.team766.hal.mock.MockBeaconSensor;
 import com.team766.hal.mock.MockGyro;
 import com.team766.hal.mock.MockPositionSensor;
 import com.team766.hal.mock.MockMotorController;
@@ -165,6 +167,18 @@ public class WPIRobotProvider extends RobotProvider {
 			);
 		}
 		return positionSensor;
+	}
+
+	@Override
+	public BeaconReader getBeaconSensor() {
+		if (beaconSensor == null) {
+			beaconSensor = new MockBeaconSensor();
+			Logger.get(Category.CONFIGURATION).logRaw(
+				Severity.ERROR,
+				"Beacon sensor does not exist on real robots. Using mock beacon sensor instead - it will always return no beacons"
+			);
+		}
+		return beaconSensor;
 	}
 
 	@Override

--- a/src/main/java/com/team766/simulator/ProgramInterface.java
+++ b/src/main/java/com/team766/simulator/ProgramInterface.java
@@ -1,6 +1,7 @@
 package com.team766.simulator;
 
 import java.lang.reflect.Array;
+import com.team766.hal.BeaconReader;
 import com.team766.hal.mock.MockJoystick;
 
 public class ProgramInterface {
@@ -79,6 +80,10 @@ public class ProgramInterface {
 	}
 
 	public static final RobotPosition robotPosition = new RobotPosition();
+
+	public static final int NUM_BEACONS = 8;
+	public static BeaconReader.BeaconPose[] beacons =
+			initializeArray(NUM_BEACONS, BeaconReader.BeaconPose.class);
 	
 	public static final MockJoystick[] joystickChannels =
 			initializeArray(6, MockJoystick.class);


### PR DESCRIPTION
Add a new HAL sensor type for reading the pose of localization beacons relative to the robot's pose. Also add an implementation for the simulator (other HAL targets are stubbed for now). This will be used initially for developing AprilTag-based localization in the simulator

Some example code can be seen in https://github.com/Team766/MaroonFramework/commit/15bf080fc25d30ec8c1a9788a37a77206c2d24a1

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Team766/MaroonFramework/21)
<!-- Reviewable:end -->
