### PR TITLE
Fixed switch error with setNeutralMode() (Was fixed earlier but not added here)

### DIFF
--- a/src/main/java/com/team766/hal/wpilib/CANSparkMaxMotorController.java
+++ b/src/main/java/com/team766/hal/wpilib/CANSparkMaxMotorController.java
@@ -110,10 +110,13 @@ public class CANSparkMaxMotorController extends CANSparkMax implements MotorCont
 		switch (neutralMode) {
 			case Brake:
 				revErrorToException(ExceptionTarget.LOG, setIdleMode(IdleMode.kBrake));
+				break;
 			case Coast:
 				revErrorToException(ExceptionTarget.LOG, setIdleMode(IdleMode.kCoast));
+				break;
 			default:
 				LoggerExceptionUtils.logException(new IllegalArgumentException("Unsupported neutral mode " + neutralMode));
+				break;
 		}
 	}
 


### PR DESCRIPTION


As mentioned above, this was fixed earlier on the 2023 repo but thought to add it here. I basically added some break statements so that the switch works properly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Team766/MaroonFramework/24)
<!-- Reviewable:end -->
