### PR TITLE
add reset method to RateLimiter class

### DIFF
--- a/src/main/java/com/team766/library/RateLimiter.java
+++ b/src/main/java/com/team766/library/RateLimiter.java
@@ -25,7 +25,7 @@ public class RateLimiter {
 		}
 	}
 
-	public void reset(){
+	public void reset() {
 		nextTime = 0;
 	}
 

--- a/src/main/java/com/team766/library/RateLimiter.java
+++ b/src/main/java/com/team766/library/RateLimiter.java
@@ -25,6 +25,7 @@ public class RateLimiter {
 		}
 	}
 
+	/** Restarts the timer. */
 	public void reset() {
 		nextTime = 0;
 	}

--- a/src/main/java/com/team766/library/RateLimiter.java
+++ b/src/main/java/com/team766/library/RateLimiter.java
@@ -24,4 +24,9 @@ public class RateLimiter {
 			return false;
 		}
 	}
+
+	public void reset(){
+		nextTime = 0;
+	}
+
 }


### PR DESCRIPTION
`RateLimiter` is a class we've occasionally used when we need to make the code wait for a specified period of time without interrupting the rest of the code. I think it would be helpful if the class had a method that simply resets the `RateLimiter`'s "timer". 

For example, let's say someone wants to use `RateLimiter` every 2 seconds. As soon as the `RateLimiter` is initialized, it starts checking if it has been 2 seconds since the time it was initialized. Currently, if a programmer wanted to make the `RateLimiter` restart its count at a specific part of the code, they would need to create a new `RateLimiter` object. 

So, I added a public method that allows a `RateLimiter`'s start time to be reset.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Team766/MaroonFramework/32)
<!-- Reviewable:end -->
